### PR TITLE
test(tap_parser): reproduce the bug that 4 finger tap after detecting palm

### DIFF
--- a/spec/fusuma/plugin/parsers/1.10.4/4finger-tap-after-palm-detected-bug.txt
+++ b/spec/fusuma/plugin/parsers/1.10.4/4finger-tap-after-palm-detected-bug.txt
@@ -1,0 +1,27 @@
+event18 - thumb state: THUMB_STATE_MAYBE → THUMB_STATE_NO
+event18 - palm: palm detected (tool-palm)
+event18 - button state: from BUTTON_STATE_NONE, event BUTTON_EVENT_IN_AREA to BUTTON_STATE_AREA
+event18 - palm: palm detected (tool-palm)
+event18 - button state: from BUTTON_STATE_AREA, event BUTTON_EVENT_UP to BUTTON_STATE_NONE
+event18 - thumb state: THUMB_STATE_MAYBE → THUMB_STATE_NO
+event18 - button state: from BUTTON_STATE_NONE, event BUTTON_EVENT_IN_AREA to BUTTON_STATE_AREA
+event18 - thumb state: THUMB_STATE_MAYBE → THUMB_STATE_NO
+event18 - thumb state: THUMB_STATE_MAYBE → THUMB_STATE_NO
+event18 - thumb state: THUMB_STATE_MAYBE → THUMB_STATE_NO
+event18 - button state: from BUTTON_STATE_NONE, event BUTTON_EVENT_IN_AREA to BUTTON_STATE_AREA
+event18 - button state: from BUTTON_STATE_NONE, event BUTTON_EVENT_IN_AREA to BUTTON_STATE_AREA
+event18 - button state: from BUTTON_STATE_NONE, event BUTTON_EVENT_IN_AREA to BUTTON_STATE_AREA
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - button state: from BUTTON_STATE_AREA, event BUTTON_EVENT_UP to BUTTON_STATE_NONE
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - button state: from BUTTON_STATE_AREA, event BUTTON_EVENT_UP to BUTTON_STATE_NONE
+event18 - gesture state: GESTURE_STATE_UNKNOWN → GESTURE_STATE_UNKNOWN
+event18 - button state: from BUTTON_STATE_AREA, event BUTTON_EVENT_UP to BUTTON_STATE_NONE
+event18 - button state: from BUTTON_STATE_AREA, event BUTTON_EVENT_UP to BUTTON_STATE_NONE

--- a/spec/fusuma/plugin/parsers/1.14.1/4finger-tap-after-palm-detected-bug.txt
+++ b/spec/fusuma/plugin/parsers/1.14.1/4finger-tap-after-palm-detected-bug.txt
@@ -1,0 +1,20 @@
+event18 - palm: touch 0, palm detected (tool-palm)
+event18 - button state: touch 0 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - palm: touch 0, palm detected (tool-palm)
+event18 - button state: touch 0 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - button state: touch 0 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - tap: touch 0 state TAP_STATE_IDLE → TAP_EVENT_TOUCH → TAP_STATE_TOUCH
+event18 - button state: touch 1 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - button state: touch 2 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - button state: touch 3 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - tap: touch 1 state TAP_STATE_TOUCH → TAP_EVENT_TOUCH → TAP_STATE_TOUCH_2
+event18 - tap: touch 2 state TAP_STATE_TOUCH_2 → TAP_EVENT_TOUCH → TAP_STATE_TOUCH_3
+event18 - tap: touch 3 state TAP_STATE_TOUCH_3 → TAP_EVENT_TOUCH → TAP_STATE_DEAD
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - button state: touch 3 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - button state: touch 2 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - button state: touch 1 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - button state: touch 0 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - tap: touch 0 state TAP_STATE_DEAD → TAP_EVENT_RELEASE → TAP_STATE_IDLE

--- a/spec/fusuma/plugin/parsers/1.15.5/4finger-tap-after-palm-detected-bug.txt
+++ b/spec/fusuma/plugin/parsers/1.15.5/4finger-tap-after-palm-detected-bug.txt
@@ -1,0 +1,20 @@
+event18 - palm: touch 0, palm detected (tool-palm)
+event18 - button state: touch 0 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - palm: touch 0, palm detected (tool-palm)
+event18 - button state: touch 0 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - button state: touch 0 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - tap: touch 0 state TAP_STATE_IDLE → TAP_EVENT_TOUCH → TAP_STATE_TOUCH
+event18 - button state: touch 1 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - button state: touch 2 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - button state: touch 3 from BUTTON_STATE_NONE    event BUTTON_EVENT_IN_AREA     to BUTTON_STATE_AREA   
+event18 - tap: touch 1 state TAP_STATE_TOUCH → TAP_EVENT_TOUCH → TAP_STATE_TOUCH_2
+event18 - tap: touch 2 state TAP_STATE_TOUCH_2 → TAP_EVENT_TOUCH → TAP_STATE_TOUCH_3
+event18 - tap: touch 3 state TAP_STATE_TOUCH_3 → TAP_EVENT_TOUCH → TAP_STATE_DEAD
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - button state: touch 3 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - button state: touch 2 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - gesture state: GESTURE_STATE_NONE → GESTURE_STATE_UNKNOWN
+event18 - button state: touch 1 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - button state: touch 0 from BUTTON_STATE_AREA    event BUTTON_EVENT_UP          to BUTTON_STATE_NONE   
+event18 - tap: touch 0 state TAP_STATE_DEAD → TAP_EVENT_RELEASE → TAP_STATE_IDLE

--- a/spec/fusuma/plugin/parsers/evemu/4finger-tap-after-palm-detected-bug.txt
+++ b/spec/fusuma/plugin/parsers/evemu/4finger-tap-after-palm-detected-bug.txt
@@ -1,0 +1,250 @@
+# EVEMU 1.3
+# Kernel: 5.3.0-61-generic
+# DMI: dmi:bvnDellInc.:bvr2.13.0:bd11/14/2019:svnDellInc.:pnXPS139360:pvr:rvnDellInc.:rn0115N5:rvrA00:cvnDellInc.:ct9:cvr:
+# Input device name: "DLL075B:01 06CB:76AF Touchpad"
+# Input device ID: bus 0x18 vendor 0x6cb product 0x76af version 0x100
+# Size in mm: 101x56
+# Supported events:
+#   Event type 0 (EV_SYN)
+#     Event code 0 (SYN_REPORT)
+#     Event code 1 (SYN_CONFIG)
+#     Event code 2 (SYN_MT_REPORT)
+#     Event code 3 (SYN_DROPPED)
+#     Event code 4 ((null))
+#     Event code 5 ((null))
+#     Event code 6 ((null))
+#     Event code 7 ((null))
+#     Event code 8 ((null))
+#     Event code 9 ((null))
+#     Event code 10 ((null))
+#     Event code 11 ((null))
+#     Event code 12 ((null))
+#     Event code 13 ((null))
+#     Event code 14 ((null))
+#     Event code 15 (SYN_MAX)
+#   Event type 1 (EV_KEY)
+#     Event code 272 (BTN_LEFT)
+#     Event code 325 (BTN_TOOL_FINGER)
+#     Event code 328 (BTN_TOOL_QUINTTAP)
+#     Event code 330 (BTN_TOUCH)
+#     Event code 333 (BTN_TOOL_DOUBLETAP)
+#     Event code 334 (BTN_TOOL_TRIPLETAP)
+#     Event code 335 (BTN_TOOL_QUADTAP)
+#   Event type 3 (EV_ABS)
+#     Event code 0 (ABS_X)
+#       Value        0
+#       Min          0
+#       Max       1216
+#       Fuzz         0
+#       Flat         0
+#       Resolution  12
+#     Event code 1 (ABS_Y)
+#       Value      294
+#       Min          0
+#       Max        680
+#       Fuzz         0
+#       Flat         0
+#       Resolution  12
+#     Event code 47 (ABS_MT_SLOT)
+#       Value        0
+#       Min          0
+#       Max          4
+#       Fuzz         0
+#       Flat         0
+#       Resolution   0
+#     Event code 53 (ABS_MT_POSITION_X)
+#       Value        0
+#       Min          0
+#       Max       1216
+#       Fuzz         0
+#       Flat         0
+#       Resolution  12
+#     Event code 54 (ABS_MT_POSITION_Y)
+#       Value        0
+#       Min          0
+#       Max        680
+#       Fuzz         0
+#       Flat         0
+#       Resolution  12
+#     Event code 55 (ABS_MT_TOOL_TYPE)
+#       Value        0
+#       Min          0
+#       Max          2
+#       Fuzz         0
+#       Flat         0
+#       Resolution   0
+#     Event code 57 (ABS_MT_TRACKING_ID)
+#       Value        0
+#       Min          0
+#       Max      65535
+#       Fuzz         0
+#       Flat         0
+#       Resolution   0
+#   Event type 4 (EV_MSC)
+#     Event code 5 (MSC_TIMESTAMP)
+# Properties:
+#   Property  type 0 (INPUT_PROP_POINTER)
+#   Property  type 2 (INPUT_PROP_BUTTONPAD)
+N: DLL075B:01 06CB:76AF Touchpad
+I: 0018 06cb 76af 0100
+P: 05 00 00 00 00 00 00 00
+B: 00 0b 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 01 00 00 00 00 00
+B: 01 20 e5 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 01 00 00 00 00 00 00 00 00
+B: 02 00 00 00 00 00 00 00 00
+B: 03 03 00 00 00 00 80 e0 02
+B: 04 20 00 00 00 00 00 00 00
+B: 05 00 00 00 00 00 00 00 00
+B: 11 00 00 00 00 00 00 00 00
+B: 12 00 00 00 00 00 00 00 00
+B: 14 00 00 00 00 00 00 00 00
+B: 15 00 00 00 00 00 00 00 00
+B: 15 00 00 00 00 00 00 00 00
+A: 00 0 1216 0 0 12
+A: 01 0 680 0 0 12
+A: 2f 0 4 0 0 0
+A: 35 0 1216 0 0 12
+A: 36 0 680 0 0 12
+A: 37 0 2 0 0 0
+A: 39 0 65535 0 0 0
+################################
+#      Waiting for events      #
+################################
+E: 0.000001 0003 0039 37243	# EV_ABS / ABS_MT_TRACKING_ID   37243
+E: 0.000001 0003 0037 0002	# EV_ABS / ABS_MT_TOOL_TYPE     2
+E: 0.000001 0003 0035 0915	# EV_ABS / ABS_MT_POSITION_X    915
+E: 0.000001 0003 0036 0247	# EV_ABS / ABS_MT_POSITION_Y    247
+E: 0.000001 0001 014a 0001	# EV_KEY / BTN_TOUCH            1
+E: 0.000001 0001 0145 0001	# EV_KEY / BTN_TOOL_FINGER      1
+E: 0.000001 0003 0000 0915	# EV_ABS / ABS_X                915
+E: 0.000001 0003 0001 0247	# EV_ABS / ABS_Y                247
+E: 0.000001 0004 0005 0000	# EV_MSC / MSC_TIMESTAMP        0
+E: 0.000001 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +0ms
+E: 0.005387 0004 0005 7100	# EV_MSC / MSC_TIMESTAMP        7100
+E: 0.005387 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +5ms
+E: 0.005402 0003 0039 -001	# EV_ABS / ABS_MT_TRACKING_ID   -1
+E: 0.005402 0001 014a 0000	# EV_KEY / BTN_TOUCH            0
+E: 0.005402 0001 0145 0000	# EV_KEY / BTN_TOOL_FINGER      0
+E: 0.005402 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +0ms
+E: 0.921806 0003 0039 37244	# EV_ABS / ABS_MT_TRACKING_ID   37244
+E: 0.921806 0003 0037 0000	# EV_ABS / ABS_MT_TOOL_TYPE     0
+E: 0.921806 0003 0035 0957	# EV_ABS / ABS_MT_POSITION_X    957
+E: 0.921806 0003 0036 0264	# EV_ABS / ABS_MT_POSITION_Y    264
+E: 0.921806 0001 014a 0001	# EV_KEY / BTN_TOUCH            1
+E: 0.921806 0001 0145 0001	# EV_KEY / BTN_TOOL_FINGER      1
+E: 0.921806 0003 0000 0957	# EV_ABS / ABS_X                957
+E: 0.921806 0003 0001 0264	# EV_ABS / ABS_Y                264
+E: 0.921806 0004 0005 931700	# EV_MSC / MSC_TIMESTAMP        931700
+E: 0.921806 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +916ms
+E: 0.930578 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.930578 0003 0039 37245	# EV_ABS / ABS_MT_TRACKING_ID   37245
+E: 0.930578 0003 0035 0476	# EV_ABS / ABS_MT_POSITION_X    476
+E: 0.930578 0003 0036 0161	# EV_ABS / ABS_MT_POSITION_Y    161
+E: 0.930578 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
+E: 0.930578 0003 0039 37246	# EV_ABS / ABS_MT_TRACKING_ID   37246
+E: 0.930578 0003 0035 0276	# EV_ABS / ABS_MT_POSITION_X    276
+E: 0.930578 0003 0036 0272	# EV_ABS / ABS_MT_POSITION_Y    272
+E: 0.930578 0003 002f 0003	# EV_ABS / ABS_MT_SLOT          3
+E: 0.930578 0003 0039 37247	# EV_ABS / ABS_MT_TRACKING_ID   37247
+E: 0.930578 0003 0035 0693	# EV_ABS / ABS_MT_POSITION_X    693
+E: 0.930578 0003 0036 0134	# EV_ABS / ABS_MT_POSITION_Y    134
+E: 0.930578 0001 0145 0000	# EV_KEY / BTN_TOOL_FINGER      0
+E: 0.930578 0001 014f 0001	# EV_KEY / BTN_TOOL_QUADTAP     1
+E: 0.930578 0004 0005 938900	# EV_MSC / MSC_TIMESTAMP        938900
+E: 0.930578 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +9ms
+E: 0.938350 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.938350 0003 0036 0172	# EV_ABS / ABS_MT_POSITION_Y    172
+E: 0.938350 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
+E: 0.938350 0003 0035 0273	# EV_ABS / ABS_MT_POSITION_X    273
+E: 0.938350 0003 0036 0265	# EV_ABS / ABS_MT_POSITION_Y    265
+E: 0.938350 0003 002f 0003	# EV_ABS / ABS_MT_SLOT          3
+E: 0.938350 0003 0035 0698	# EV_ABS / ABS_MT_POSITION_X    698
+E: 0.938350 0003 0036 0156	# EV_ABS / ABS_MT_POSITION_Y    156
+E: 0.938350 0004 0005 946000	# EV_MSC / MSC_TIMESTAMP        946000
+E: 0.938350 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +8ms
+E: 0.945400 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 0.945400 0003 0035 0956	# EV_ABS / ABS_MT_POSITION_X    956
+E: 0.945400 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.945400 0003 0035 0475	# EV_ABS / ABS_MT_POSITION_X    475
+E: 0.945400 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
+E: 0.945400 0003 0035 0272	# EV_ABS / ABS_MT_POSITION_X    272
+E: 0.945400 0003 002f 0003	# EV_ABS / ABS_MT_SLOT          3
+E: 0.945400 0003 0035 0697	# EV_ABS / ABS_MT_POSITION_X    697
+E: 0.945400 0003 0000 0956	# EV_ABS / ABS_X                956
+E: 0.945400 0004 0005 953200	# EV_MSC / MSC_TIMESTAMP        953200
+E: 0.945400 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.952410 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 0.952410 0003 0035 0955	# EV_ABS / ABS_MT_POSITION_X    955
+E: 0.952410 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.952410 0003 0035 0474	# EV_ABS / ABS_MT_POSITION_X    474
+E: 0.952410 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
+E: 0.952410 0003 0035 0271	# EV_ABS / ABS_MT_POSITION_X    271
+E: 0.952410 0003 002f 0003	# EV_ABS / ABS_MT_SLOT          3
+E: 0.952410 0003 0035 0696	# EV_ABS / ABS_MT_POSITION_X    696
+E: 0.952410 0003 0000 0955	# EV_ABS / ABS_X                955
+E: 0.952410 0004 0005 960400	# EV_MSC / MSC_TIMESTAMP        960400
+E: 0.952410 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.959406 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 0.959406 0003 0035 0954	# EV_ABS / ABS_MT_POSITION_X    954
+E: 0.959406 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.959406 0003 0035 0473	# EV_ABS / ABS_MT_POSITION_X    473
+E: 0.959406 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
+E: 0.959406 0003 0035 0270	# EV_ABS / ABS_MT_POSITION_X    270
+E: 0.959406 0003 0000 0954	# EV_ABS / ABS_X                954
+E: 0.959406 0004 0005 967600	# EV_MSC / MSC_TIMESTAMP        967600
+E: 0.959406 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.965843 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 0.965843 0003 0035 0953	# EV_ABS / ABS_MT_POSITION_X    953
+E: 0.965843 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.965843 0003 0035 0472	# EV_ABS / ABS_MT_POSITION_X    472
+E: 0.965843 0003 002f 0003	# EV_ABS / ABS_MT_SLOT          3
+E: 0.965843 0003 0039 -001	# EV_ABS / ABS_MT_TRACKING_ID   -1
+E: 0.965843 0001 014e 0001	# EV_KEY / BTN_TOOL_TRIPLETAP   1
+E: 0.965843 0001 014f 0000	# EV_KEY / BTN_TOOL_QUADTAP     0
+E: 0.965843 0003 0000 0953	# EV_ABS / ABS_X                953
+E: 0.965843 0004 0005 974700	# EV_MSC / MSC_TIMESTAMP        974700
+E: 0.965843 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +6ms
+E: 0.972894 0004 0005 981800	# EV_MSC / MSC_TIMESTAMP        981800
+E: 0.972894 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.979864 0004 0005 989000	# EV_MSC / MSC_TIMESTAMP        989000
+E: 0.979864 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.986934 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 0.986934 0003 0035 0952	# EV_ABS / ABS_MT_POSITION_X    952
+E: 0.986934 0003 0000 0952	# EV_ABS / ABS_X                952
+E: 0.986934 0004 0005 996200	# EV_MSC / MSC_TIMESTAMP        996200
+E: 0.986934 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.993276 0003 0035 0951	# EV_ABS / ABS_MT_POSITION_X    951
+E: 0.993276 0003 002f 0002	# EV_ABS / ABS_MT_SLOT          2
+E: 0.993276 0003 0039 -001	# EV_ABS / ABS_MT_TRACKING_ID   -1
+E: 0.993276 0001 014d 0001	# EV_KEY / BTN_TOOL_DOUBLETAP   1
+E: 0.993276 0001 014e 0000	# EV_KEY / BTN_TOOL_TRIPLETAP   0
+E: 0.993276 0003 0000 0951	# EV_ABS / ABS_X                951
+E: 0.993276 0004 0005 1003400	# EV_MSC / MSC_TIMESTAMP        1003400
+E: 0.993276 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 0.999951 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 0.999951 0003 0035 0950	# EV_ABS / ABS_MT_POSITION_X    950
+E: 0.999951 0003 002f 0001	# EV_ABS / ABS_MT_SLOT          1
+E: 0.999951 0003 0039 -001	# EV_ABS / ABS_MT_TRACKING_ID   -1
+E: 0.999951 0001 0145 0001	# EV_KEY / BTN_TOOL_FINGER      1
+E: 0.999951 0001 014d 0000	# EV_KEY / BTN_TOOL_DOUBLETAP   0
+E: 0.999951 0003 0000 0950	# EV_ABS / ABS_X                950
+E: 0.999951 0004 0005 1010500	# EV_MSC / MSC_TIMESTAMP        1010500
+E: 0.999951 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +6ms
+E: 1.006997 0004 0005 1017600	# EV_MSC / MSC_TIMESTAMP        1017600
+E: 1.006997 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms
+E: 1.013350 0003 002f 0000	# EV_ABS / ABS_MT_SLOT          0
+E: 1.013350 0003 0039 -001	# EV_ABS / ABS_MT_TRACKING_ID   -1
+E: 1.013350 0001 014a 0000	# EV_KEY / BTN_TOUCH            0
+E: 1.013350 0001 0145 0000	# EV_KEY / BTN_TOOL_FINGER      0
+E: 1.013350 0004 0005 1024800	# EV_MSC / MSC_TIMESTAMP        1024800
+E: 1.013350 0000 0000 0000	# ------------ SYN_REPORT (0) ---------- +7ms

--- a/spec/fusuma/plugin/parsers/tap_parser_spec.rb
+++ b/spec/fusuma/plugin/parsers/tap_parser_spec.rb
@@ -10,9 +10,9 @@ module Fusuma
       RSpec.describe TapParser do
         describe '#parse_record' do
           before do
-            version = ENV.fetch('LIBINPUT_VERSION', '1.14.1')
+            @version = ENV.fetch('LIBINPUT_VERSION', '1.14.1')
 
-            @debug_log_version_dir = "spec/fusuma/plugin/parsers/#{version}"
+            @debug_log_version_dir = "spec/fusuma/plugin/parsers/#{@version}"
             @parser = TapParser.new
           end
           context 'with 1 finger tap' do
@@ -186,6 +186,22 @@ module Fusuma
             it 'should not generate 4 finger tap (bug)' do
               expect(@records.map(&:gesture)).to all(eq 'tap')
               expect(@records.map(&:finger).max).not_to eq 4
+            end
+          end
+
+          context 'with 4 finger tap after palm detected (bug)' do
+            before do
+              @records = File.readlines("#{@debug_log_version_dir}/4finger-tap-after-palm-detected-bug.txt").map do |line|
+                @parser.parse_record(line)
+              end.compact
+            end
+            it 'should generate 4 finger tap (bug)' do
+              # FIXME: Fail only libinput 1.10.4
+              skip if @version == '1.10.4'
+
+              expect(@records.map(&:gesture)).to all(eq 'tap')
+              expect(@records.map(&:finger).max).to eq 4
+              expect(@records.map(&:status)).to be_include 'touch'
             end
           end
         end


### PR DESCRIPTION
After palm detection occurred, we found a bug that prevented four-finger taps from being detected.

This bug appears in libinput-debug-events at libinput v1.10.4, and Fusuma cannot fix it.

## Solution: 
A. Update libinput to the latest version.
B. Build libinput manually and use it as input to `Plugin::Inputs::LibinputCommandInput`.

```yaml
plugin:
  inputs:
    libinput_command_input: # options for lib/plugin/inputs/libinput_command_input
      enable-tap: true
      enable-dwt: true
      verbose: true
      libinput-list-devices: /path/to/local/libinput/builddir/libinput-list-devices
      libinput-debug-events: /path/to/local/libinput/builddir/libinput-debug-events
```